### PR TITLE
Ajout de la simulation étape par étape du jeu de la vie

### DIFF
--- a/components/content/JeuVie.vue
+++ b/components/content/JeuVie.vue
@@ -1,34 +1,105 @@
 <template>
-  <div class="unicell" :style="{ 'justify-content': jc }">
-    <span v-if="gen" class="gen">{{ gen }}</span>
-    <div v-for="cll in arrGen" class="cell" :class="cll.value ? 'alive' : 'dead'" @click="toggleCell(cll)">&nbsp;</div>
+  <div class="content">
+    <div class="buttons">
+      <button v-if="play" @click="playSimulation()" class="play-button">Play</button>
+      <button v-if="reset" @click="resetSimulation()" class="reset-button">Reset</button>
+    </div>
+    <div class="unicell" :style="{ 'justify-content': jc }">
+      <span v-if="gen" class="gen">Gen. {{ gen }}</span>
+      <div v-for="(cll, index) in arrGen" :key="index" class="cell" :class="{ 'alive': cll, 'dead': !cll }"
+        @click="toggleCell(index)"></div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
+
 const props = defineProps({
-  code: {
-    type: String
-  },
-  gen: {
-    type: String
-  },
-  jc: {
-    type: String
+  code: String,
+  gen: String,
+  jc: String,
+  play: String,
+  reset: String,
+  step: String
+});
+
+let arrGen = ref(props.code ? props.code.split('').map(c => c === '1') : []);
+
+const originalArrGen = ref([...arrGen.value]); // Create a deep copy or the original array
+
+
+function playSimulation(generation : number) {
+  const newArray = ref([...arrGen.value]);
+
+  for (let i = 0; i < arrGen.value.length; i++) {
+    let cells = [];
+    if (i > 0) {
+      cells.push(arrGen.value[i - 1]);
+    }
+
+    if (i < arrGen.value.length - 1) {
+      cells.push(arrGen.value[i + 1]);
+    }
+
+
+    if (arrGen.value[i] === false) {
+      let a = 0;
+      cells.forEach(v => {
+        if (v === true) {
+          a++
+        };
+      })
+      if (a != 0) {
+        newArray.value[i] = !newArray.value[i];
+      }
+    }
   }
-})
+  arrGen.value = [...newArray.value];
+}
 
-const arrGen = computed(() => {
-  const arrTmp = props.code.split('')
-  return arrTmp.map(x => ref(parseInt(x)))
-})
+function resetSimulation() {
+  arrGen.value = [...originalArrGen.value];
+}
 
-function toggleCell(cll) {
-  cll.value = !cll.value;
+function toggleCell(index: string | number) {
+  arrGen.value[index] = !arrGen.value[index];
 }
 </script>
 
 <style scoped>
+.content {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+}
+
+.buttons {
+  position: absolute;
+  left: 0;
+}
+
+.play-button {
+  background-color: darkgreen;
+  color: white;
+  border: none;
+  padding: 5px 15px;
+  margin-right: 10px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.reset-button {
+  background-color: darkred;
+  color: white;
+  border: none;
+  padding: 5px 15px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
 .cell {
   width: 2rem;
   height: 2rem;
@@ -52,6 +123,7 @@ function toggleCell(cll) {
 }
 
 .unicell {
+  margin-left: 1vw;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/content/2.nsi/3.algorithmique/2.jeu-vie.md
+++ b/content/2.nsi/3.algorithmique/2.jeu-vie.md
@@ -24,7 +24,7 @@ Partant de cette grille unidimensionnelle, considérons que la couleur de chaque
 À chaque nouvelle génération, on applique cette règle à toutes les cellules
 ::
 
-:jeu-vie{code="000010000" gen="1" play=""}
+:jeu-vie{code="000010000" gen="1"}
 :jeu-vie{code="000111000" gen="2"}
 :jeu-vie{code="001111100" gen="3"}
 :jeu-vie{code="011111110" gen="4"}

--- a/content/2.nsi/3.algorithmique/2.jeu-vie.md
+++ b/content/2.nsi/3.algorithmique/2.jeu-vie.md
@@ -24,10 +24,10 @@ Partant de cette grille unidimensionnelle, considérons que la couleur de chaque
 À chaque nouvelle génération, on applique cette règle à toutes les cellules
 ::
 
-:jeu-vie{code="000010000" gen="gen. 1"}
-:jeu-vie{code="000111000" gen="gen. 2"}
-:jeu-vie{code="001111100" gen="gen. 3"}
-:jeu-vie{code="011111110" gen="gen. 4"}
+:jeu-vie{code="000010000" gen="1" play=""}
+:jeu-vie{code="000111000" gen="2"}
+:jeu-vie{code="001111100" gen="3"}
+:jeu-vie{code="011111110" gen="4"}
 
 Sur plusieurs générations successives, nous pouvons superposer les lignes obtenues et ainsi obtenir une image qui sera une représentation graphique de la règle que nous avons considérée.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "follow-redirects": "^1.15.2",
+        "nuxi": "^3.7.3",
         "nuxt-content-assets": "^1.3.2"
       },
       "devDependencies": {
@@ -13103,7 +13104,6 @@
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/nuxi/-/nuxi-3.7.3.tgz",
       "integrity": "sha512-Cg+ygRmhonE6PwAtDeKvKU/0VRqEyzmSSoJYfr0MzwIxQYrBSnLvw0z3UgJl/8MgFKjiZ5Y4wBUEiRsUw8O6uw==",
-      "dev": true,
       "bin": {
         "nuxi": "bin/nuxi.mjs",
         "nuxi-ng": "bin/nuxi.mjs",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "follow-redirects": "^1.15.2",
+    "nuxi": "^3.7.3",
     "nuxt-content-assets": "^1.3.2"
   }
 }


### PR DESCRIPTION
Changed :
Adding the parameters "play", and "reset" with any value to the component JeuVie (e.g. " 2.jeu-vie.md " ) allows the simulation to play 1 step/reset to the base state (defined by the parameter code)
Changed 2.jeu-vie.md to support the new format for calling the component:
E.g. :
```
:jeu-vie{code="000111000" gen="Gen. 2"}
```
=>
```
:jeu-vie{code="000111000" gen="2"}
```